### PR TITLE
Add another pytorch version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Worked:
 - Stable (2.1.2), CUDA 11.8, Pre-cxx11 ABI
 
 Did **not** work:
-- TODO
+- Stable (2.2.2), CUDA 11.8, Pre-cxx11 ABI


### PR DESCRIPTION
Tried pytorch 2.2, build failed with c++ compiler errors