### PR TITLE
Print centipawn score, nps and pv in tei mode

### DIFF
--- a/tei/src/main.rs
+++ b/tei/src/main.rs
@@ -189,11 +189,15 @@ fn go(net: &Net, env: &Env, node: &mut Node<Env>, go_options: Vec<GoOption>) {
         let elapsed = start.elapsed();
 
         if visits % NODES_PER_INFO == 0 {
-            println!("{}", Output::Info {
-                time: elapsed,
-                nodes: visits,
-                score: node.evaluation,
-            });
+            println!(
+                "{}",
+                Output::Info {
+                    time: elapsed,
+                    nodes: visits,
+                    score: node.evaluation,
+                    principal_variation: node.principal_variation().collect(),
+                }
+            );
         }
 
         if nodes.is_some_and(|amount| visits >= amount)

--- a/tei/src/protocol.rs
+++ b/tei/src/protocol.rs
@@ -175,6 +175,7 @@ pub enum Output {
         time: Duration,
         nodes: usize,
         score: Eval,
+        principal_variation: Vec<Move>,
     },
 }
 
@@ -235,15 +236,27 @@ impl fmt::Display for Output {
             Self::Ok => write!(f, "teiok"),
             Self::ReadyOk => write!(f, "readyok"),
             Self::BestMove(the_move) => write!(f, "bestmove {the_move}"),
-            Self::Info { time, nodes, score } => {
+            Self::Info {
+                time,
+                nodes,
+                score,
+                principal_variation,
+            } => {
                 let centipawns = (f32::from(*score) * 100.0) as i32;
                 write!(
                     f,
-                    "info time {} nodes {nodes} score {centipawns}",
-                    time.as_millis()
+                    "info time {} nodes {nodes} nps {}",
+                    time.as_millis(),
+                    1000 * nodes / time.as_millis() as usize,
                 )?;
                 if let Some(ply) = score.ply() {
-                    write!(f, " mate {ply}")?;
+                    write!(f, " score mate {ply}")?;
+                } else {
+                    write!(f, " score cp {centipawns}")?;
+                }
+                write!(f, " pv")?;
+                for mv in principal_variation {
+                    write!(f, " {mv}")?;
                 }
                 Ok(())
             }


### PR DESCRIPTION
Score was already being printed in the tei `info` string, but without the `cp` prefix, so Racetrack didn't parse it correctly.